### PR TITLE
fix(transport): handle timedelta elapsed in curl_cffi 0.14+

### DIFF
--- a/httpx_curl_cffi/transport.py
+++ b/httpx_curl_cffi/transport.py
@@ -350,7 +350,10 @@ class BaseCurlTransport(Generic[SessionT]):
 
         # `response.elapsed` will be updated by `httpx.Client` one more time
         # when stream will be closed
-        resp.elapsed = timedelta(seconds=_resp.elapsed)
+        if isinstance(_resp.elapsed, timedelta):
+            resp.elapsed = _resp.elapsed
+        else:
+            resp.elapsed = timedelta(seconds=_resp.elapsed)
         return resp
 
     def _create_error(


### PR DESCRIPTION
In curl_cffi 0.14.0b4, `Response.elapsed` is now a `datetime.timedelta` object instead of a numeric value (see https://github.com/lexiforest/curl_cffi/pull/661). This caused a `TypeError` when creating httpx responses:

```
TypeError: unsupported type for timedelta seconds component: datetime.timedelta
```

This PR adds a type check to handle both old (numeric) and new (timedelta) versions.

### Test plan
- Tested with curl_cffi 0.13.0 - all tests pass
- Tested with curl_cffi 0.14.0b5 - all tests pass
